### PR TITLE
Add support for read-only fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Table of Contents
    * [Table of Contents](#table-of-contents)
    * [What Is json_dto?](#what-is-json_dto)
    * [What's new?](#whats-new)
+      * [v.0.2.12](#v0212)
       * [v.0.2.11](#v0211)
       * [v.0.2.10](#v0210)
       * [v.0.2.9](#v029)
@@ -63,6 +64,10 @@ And since Fall 2016 is ready for public. We are still using it for
 working with JSON in various projects.
 
 # What's new?
+
+## v.0.2.12
+
+Added new `readonly` function which works like `optional_no_default`, but it only ever writes the field to JSON, and completely ignores it when reading JSON. Supports `const` fields.
 
 ## v.0.2.11
 

--- a/dev/test/CMakeLists.txt
+++ b/dev/test/CMakeLists.txt
@@ -18,4 +18,4 @@ add_subdirectory(user_defined_io_2)
 add_subdirectory(validators)
 add_subdirectory(ensure_object)
 add_subdirectory(from_string_ref)
-
+add_subdirectory(readonly_fields)

--- a/dev/test/readonly_fields/CMakeLists.txt
+++ b/dev/test/readonly_fields/CMakeLists.txt
@@ -1,0 +1,2 @@
+set(UNITTEST _unit.test.readonly_fields)
+include(${CMAKE_SOURCE_DIR}/cmake/unittest.cmake)

--- a/dev/test/readonly_fields/main.cpp
+++ b/dev/test/readonly_fields/main.cpp
@@ -1,0 +1,61 @@
+#include <catch2/catch.hpp>
+
+#include <json_dto/pub.hpp>
+
+struct data_t
+{
+	const bool m_single;
+	std::vector<bool> m_multi;
+
+	template<typename I>
+	void json_io(I & io)
+	{
+		io & json_dto::readonly("single", m_single)
+			& json_dto::mandatory("multi", m_multi);
+	}
+};
+
+TEST_CASE( "read from json ignores readonly field" , "read" )
+{
+	{
+        data_t obj{ true, { true, false, false }};
+		const std::string json_data{
+			R"JSON(
+			{"single":false, "multi":[false, true]}
+			)JSON" };
+		json_dto::from_json< data_t >( json_data, obj );
+
+		REQUIRE( obj.m_single );
+		REQUIRE( 2 == obj.m_multi.size() );
+		REQUIRE( !obj.m_multi[0] );
+		REQUIRE( obj.m_multi[1] );
+	}
+}
+
+TEST_CASE( "read from json succeeds without readonly field", "read" )
+{
+	{
+        data_t obj{ true, { true, false, false }};
+		const std::string json_data{
+			R"JSON(
+			{"multi":[false, true]}
+			)JSON" };
+		json_dto::from_json< data_t >( json_data, obj );
+
+		REQUIRE( obj.m_single );
+		REQUIRE( 2 == obj.m_multi.size() );
+		REQUIRE( !obj.m_multi[0] );
+		REQUIRE( obj.m_multi[1] );
+	}
+}
+
+TEST_CASE( "write to json" , "write" )
+{
+	{
+		data_t obj{ true, {true, false, true}};
+		const auto r = json_dto::to_json( obj );
+
+		REQUIRE( R"({"single":true,"multi":[true,false,true]})" == r );
+	}
+}
+

--- a/dev/test/readonly_fields/prj.rb
+++ b/dev/test/readonly_fields/prj.rb
@@ -1,0 +1,10 @@
+require 'mxx_ru/cpp'
+MxxRu::Cpp::exe_target {
+	required_prj 'rapidjson_mxxru/prj.rb'
+	required_prj 'test/catch_main/prj.rb'
+
+	target( "_unit.test.readonly_fields" )
+
+	cpp_source( "main.cpp" )
+}
+

--- a/dev/test/readonly_fields/prj.ut.rb
+++ b/dev/test/readonly_fields/prj.ut.rb
@@ -1,0 +1,9 @@
+require 'mxx_ru/binary_unittest'
+
+path = 'test/readonly_fields'
+
+Mxx_ru::setup_target(
+	Mxx_ru::Binary_unittest_target.new(
+		"#{path}/prj.ut.rb",
+		"#{path}/prj.rb" )
+)


### PR DESCRIPTION
This implements the feature request in https://github.com/Stiffstream/json_dto/issues/11

It works for me, but feel free to change it around, or let me know if there's specific things you'd like me to change in it. I tried to follow the existing code style as much as possible.