### PR TITLE
Allow null for `std::optional`

### DIFF
--- a/dev/json_dto/pub.hpp
+++ b/dev/json_dto/pub.hpp
@@ -1604,6 +1604,15 @@ default_on_null( nullable_t< Field_Type > & f )
 	f.reset();
 }
 
+#if defined( JSON_DTO_SUPPORTS_STD_OPTIONAL )
+template< typename FieldType >
+void
+default_on_null( std::optional< FieldType > & f )
+{
+    f.reset();
+}
+#endif
+
 template< typename Field_Type, typename Field_Default_Value_Type >
 void
 set_default_value( Field_Type & f, Field_Default_Value_Type && default_value )


### PR DESCRIPTION
This ensures the same behaviour for `std::optional` that we get for `json_dto::nullable_t`: It won't fail when feeding it a null value. I think this makes sense, as `json_dto::nullable_t` is documented as being an "alternative for std::optional".