### PR TITLE
Fix undefined behaviour with reinterpret_cast in nullable_t

### DIFF
--- a/dev/json_dto/pub.hpp
+++ b/dev/json_dto/pub.hpp
@@ -1150,13 +1150,21 @@ struct nullable_t
 		Field_Type *
 		field_ptr() noexcept
 		{
+#if __cpp_lib_launder >= 201606L
+			return std::launder( reinterpret_cast< Field_Type * >( m_image_space ) );
+#else
 			return reinterpret_cast< Field_Type * >( m_image_space );
+#endif
 		}
 
 		const Field_Type *
 		field_ptr() const noexcept
 		{
+#if __cpp_lib_launder >= 201606L
+			return std::launder( reinterpret_cast< const Field_Type * >( m_image_space ));
+#else
 			return reinterpret_cast< const Field_Type * >( m_image_space );
+#endif
 		}
 
 		Field_Type &


### PR DESCRIPTION
Since c++17 it is mandatory launder memory when casting an address to a different type that was constructed there with placement-new. Not doing this is undefined behaviour.

We use the feature-flag defined by the standard library to detect whether it is correctly defined inside the standard library.